### PR TITLE
Add missing Clone derivations to allow BgpAttrItem to be Clone

### DIFF
--- a/src/afi/mod.rs
+++ b/src/afi/mod.rs
@@ -156,7 +156,7 @@ impl<'de> serde::Deserialize<'de> for BgpNet {
 }
 
 /// Represents variance of NLRI collections
-#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "serialization")]
 #[derive(Serialize, Deserialize)]
 pub enum BgpAddrs {

--- a/src/message/attributes/attrset.rs
+++ b/src/message/attributes/attrset.rs
@@ -13,7 +13,7 @@ use crate::message::attributes::*;
 use serde::{Deserialize, Serialize};
 
 /// BGP attribute set path attribute struct
-#[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "serialization")]
 #[derive(Serialize, Deserialize)]
 pub struct BgpAttrSet {

--- a/src/message/attributes/mod.rs
+++ b/src/message/attributes/mod.rs
@@ -59,7 +59,7 @@ pub trait BgpAttr: std::fmt::Display + std::fmt::Debug {
 }
 
 /// BGP path attribute
-#[derive(Debug, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialOrd, Ord, PartialEq, Eq)]
 #[cfg(feature = "serialization")]
 #[derive(Serialize, Deserialize)]
 pub enum BgpAttrItem {

--- a/src/message/attributes/multiproto.rs
+++ b/src/message/attributes/multiproto.rs
@@ -12,7 +12,7 @@ use crate::prelude::*;
 use serde::{Deserialize, Serialize};
 
 /// BGP multiprotocol updates
-#[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "serialization")]
 #[derive(Serialize, Deserialize)]
 pub struct BgpMPUpdates {
@@ -192,7 +192,7 @@ impl BgpAttr for BgpMPUpdates {
 }
 
 /// BGP multiprotocol withdraws
-#[derive(Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "serialization")]
 #[derive(Serialize, Deserialize)]
 pub struct BgpMPWithdraws {


### PR DESCRIPTION
This commit had the added benefit of deriving Clone for BgpAddrs