### PR TITLE
change default logging level to Trace to avoid unexpected logging

### DIFF
--- a/src/afi/mod.rs
+++ b/src/afi/mod.rs
@@ -870,7 +870,7 @@ impl BgpAddrs {
                         match decode_bgpaddritems_from(BgpTransportMode::IPv4, buf) {
                             Ok(r) => Ok((BgpAddrs::MVPN(r.0), r.1)),
                             Err(e) => {
-                                log::debug!("MVPN decode error: {:?}\nbuf:{:?}", e, buf);
+                                log::trace!("MVPN decode error: {:?}\nbuf:{:?}", e, buf);
                                 Err(e)
                             }
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -672,7 +672,7 @@ impl BgpSessionParams {
             if let BgpCapability::CapASN32(n) = cap {
                 self.has_as32bit = true;
                 if self.as_num != 0 && self.as_num != 23456 && self.as_num != *n {
-                    log::warn!(
+                    log::trace!(
                         "Capability 32-bit AS mismatch AS number: {:?}!={:?}",
                         self.as_num, *n
                     );

--- a/src/message/attributes/mod.rs
+++ b/src/message/attributes/mod.rs
@@ -139,7 +139,7 @@ impl BgpAttrItem {
             }
             128 => Ok(BgpAttrItem::AttrSet(BgpAttrSet::decode_from(peer, buf)?)),
             _ => {
-                log::debug!(
+                log::trace!(
                     "Unknown PA TC={:?} flags={:?} len={:?}: {:?}",
                     typecode,
                     flags,

--- a/src/message/attributes/multiproto.rs
+++ b/src/message/attributes/multiproto.rs
@@ -86,7 +86,7 @@ impl BgpMPUpdates {
                         curpos += r.1;
                     }
                     n => {
-                        log::debug!("AFI/SAFI {}/{} {:?}", afi, safi, &buf[curpos..]);
+                        log::trace!("AFI/SAFI {}/{} {:?}", afi, safi, &buf[curpos..]);
                         return Err(BgpError::from_string(format!(
                             "Unknown safi for ipv4 code {:?}",
                             n

--- a/src/message/open.rs
+++ b/src/message/open.rs
@@ -65,7 +65,7 @@ impl BgpMessage for BgpOpenMessage {
                 pos += maybe_cap.1;
                 match maybe_cap.0 {
                     Ok(cap) => self.caps.push(cap),
-                    Err((captype, data)) => log::info!("ignoring unknown capability code {} data {:x?}", captype, data),
+                    Err((captype, data)) => log::trace!("ignoring unknown capability code {} data {:x?}", captype, data),
                 }
             }
         }


### PR DESCRIPTION
Consuming applications often have well defined logging structure.  This commit transitions default library log levels to Trace.