### PR TITLE
Complete EVPN support

### DIFF
--- a/src/afi/evpn.rs
+++ b/src/afi/evpn.rs
@@ -416,7 +416,30 @@ impl BgpAddrItem<BgpEVPN> for BgpEVPN {
             ))),
         }
     }
-    fn encode_to(&self, _mode: BgpTransportMode, _buf: &mut [u8]) -> Result<usize, BgpError> {
-        unimplemented!();
+    fn encode_to(&self, mode: BgpTransportMode, buf: &mut [u8]) -> Result<usize, BgpError> {
+        let pos = match self {
+            Self::EVPN1(r) => {
+                buf[0] = 1;
+                r.encode_to(mode, &mut buf[2..])?
+            }
+            Self::EVPN2(r) => {
+                buf[0] = 2;
+                r.encode_to(mode, &mut buf[2..])?
+            }
+            Self::EVPN3(r) => {
+                buf[0] = 3;
+                r.encode_to(mode, &mut buf[2..])?
+            }
+            Self::EVPN4(r) => {
+                buf[0] = 4;
+                r.encode_to(mode, &mut buf[2..])?
+            }
+        };
+        match pos {
+            0..=0xff => buf[1] = pos as u8,
+            _ => return Err(BgpError::TooManyData),
+        }
+
+        Ok(pos + 2)
     }
 }

--- a/src/afi/evpn.rs
+++ b/src/afi/evpn.rs
@@ -156,10 +156,9 @@ impl BgpAddrItem<BgpEVPN2> for BgpEVPN2 {
     }
     fn encode_to(&self, mode: BgpTransportMode, buf: &mut [u8]) -> Result<usize, BgpError> {
         let mut pos = self.rd.encode_to(mode, buf)?;
-        buf[pos] = self.esi_type;
-        pos += 1;
         if self.esi.v.len() == 10 {
             buf[pos..pos + 10].copy_from_slice(self.esi.v.as_slice());
+            buf[pos] = self.esi_type;
             pos += 10;
         } else {
             return Err(BgpError::static_str("l2vpn esi len != 10"));

--- a/src/afi/evpn.rs
+++ b/src/afi/evpn.rs
@@ -77,8 +77,19 @@ impl BgpAddrItem<BgpEVPN1> for BgpEVPN1 {
             rdp.1 + 14 + lbls.1,
         ))
     }
-    fn encode_to(&self, _mode: BgpTransportMode, _buf: &mut [u8]) -> Result<usize, BgpError> {
-        unimplemented!();
+    fn encode_to(&self, mode: BgpTransportMode, buf: &mut [u8]) -> Result<usize, BgpError> {
+        let mut pos = self.rd.encode_to(mode, buf)?;
+        if self.esi.v.len() == 10 {
+            buf[pos..pos + 10].copy_from_slice(self.esi.v.as_slice());
+            buf[pos] = self.esi_type;
+            pos += 10;
+        } else {
+            return Err(BgpError::static_str("l2vpn esi len != 10"));
+        }
+        setn_u32(self.ether_tag, &mut buf[pos..pos + 4]);
+        pos += 4;
+        let lbls = self.labels.set_bits_to(&mut buf[pos..])?;
+        Ok(pos + lbls.1)
     }
 }
 impl std::fmt::Display for BgpEVPN1 {

--- a/src/afi/evpn.rs
+++ b/src/afi/evpn.rs
@@ -362,6 +362,109 @@ impl std::fmt::Display for BgpEVPN4 {
     }
 }
 
+/// EVPN Prefix Advertisement Route
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg(feature = "serialization")]
+#[derive(Serialize, Deserialize)]
+pub struct BgpEVPN5 {
+    pub rd: BgpRD,
+    pub esi_type: u8,
+    pub esi: EVPNESI,
+    pub ether_tag: u32,
+    pub len: u8,
+    pub prefix: IpAddr,
+    pub gw_ip: IpAddr,
+    pub labels: MplsLabels,
+}
+impl BgpAddrItem<BgpEVPN5> for BgpEVPN5 {
+    fn decode_from(mode: BgpTransportMode, buf: &[u8]) -> Result<(BgpEVPN5, usize), BgpError> {
+        let (rd, mut pos) = BgpRD::decode_from(mode, buf)?;
+        let esi_type = buf[pos];
+        let esib = &buf[pos + 1..pos + 10];
+        pos += 10;
+        let etag = getn_u32(&buf[pos..]);
+        pos += 4;
+        let len = buf[pos];
+        pos += 1;
+        let pfx;
+        let gw;
+        if buf.len() == 34 {
+            pfx = decode_addrv4_from(&buf[pos..])?.into();
+            gw = decode_addrv4_from(&buf[pos + 4..])?.into();
+            pos += 8;
+        } else if buf.len() == 58 {
+            pfx = decode_addrv4_from(&buf[pos..])?.into();
+            gw = decode_addrv4_from(&buf[pos + 16..])?.into();
+            pos += 32;
+        } else {
+            return Err(BgpError::from_string(format!(
+                "Expected an EVPN type-5 route of length 34 or 58, found {}",
+                buf.len()
+            )));
+        }
+        let lbls = MplsLabels::extract_bits_from((8 * (buf.len() - pos)) as u8, &buf[pos..])?;
+        Ok((
+            BgpEVPN5 {
+                rd,
+                esi_type,
+                esi: EVPNESI::new(esib),
+                ether_tag: etag,
+                len,
+                prefix: pfx,
+                gw_ip: gw,
+                labels: lbls.0,
+            },
+            pos + lbls.1,
+        ))
+    }
+    fn encode_to(&self, mode: BgpTransportMode, buf: &mut [u8]) -> Result<usize, BgpError> {
+        let mut pos = self.rd.encode_to(mode, buf)?;
+        if self.esi.v.len() == 10 {
+            buf[pos..pos + 10].copy_from_slice(self.esi.v.as_slice());
+            buf[pos] = self.esi_type;
+            pos += 10;
+        } else {
+            return Err(BgpError::static_str("l2vpn esi len != 10"));
+        }
+        setn_u32(self.ether_tag, &mut buf[pos..pos + 4]);
+        pos += 4;
+        buf[pos] = self.len;
+        pos += 1;
+        match (self.prefix, self.gw_ip) {
+            (IpAddr::V4(prefix), IpAddr::V4(gw)) => {
+                encode_addrv4_to(&prefix, &mut buf[pos..])?;
+                encode_addrv4_to(&gw, &mut buf[pos + 4..])?;
+                pos += 8;
+            }
+            (IpAddr::V6(prefix), IpAddr::V6(gw)) => {
+                encode_addrv6_to(&prefix, &mut buf[pos..])?;
+                encode_addrv6_to(&gw, &mut buf[pos + 16..])?;
+                pos += 16;
+            }
+            _ => {
+                return Err(BgpError::static_str(
+                    "prefix and gateway ip are of different address families",
+                ))
+            }
+        }
+        let lbls = self.labels.set_bits_to(&mut buf[pos..])?;
+        Ok(pos + lbls.1)
+    }
+}
+impl std::fmt::Display for BgpEVPN5 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:", self.rd)?;
+        if self.esi_type != 0 {
+            write!(f, "{}:", self.esi_type)?;
+        }
+        write!(
+            f,
+            "{}:{}:{}/{}:{}:{}",
+            self.esi, self.ether_tag, self.prefix, self.len, self.gw_ip, self.labels
+        )
+    }
+}
+
 /// EVPN route NLRI
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(feature = "serialization")]
@@ -371,6 +474,7 @@ pub enum BgpEVPN {
     EVPN2(BgpEVPN2),
     EVPN3(BgpEVPN3),
     EVPN4(BgpEVPN4),
+    EVPN5(BgpEVPN5),
 }
 impl std::fmt::Display for BgpEVPN {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -379,6 +483,7 @@ impl std::fmt::Display for BgpEVPN {
             BgpEVPN::EVPN2(s) => write!(f, "2:{}", s),
             BgpEVPN::EVPN3(s) => write!(f, "3:{}", s),
             BgpEVPN::EVPN4(s) => write!(f, "4:{}", s),
+            BgpEVPN::EVPN5(s) => write!(f, "5:{}", s),
         }
     }
 }
@@ -410,6 +515,10 @@ impl BgpAddrItem<BgpEVPN> for BgpEVPN {
                 let r = BgpEVPN4::decode_from(mode, &buf[2..(2 + routelen)])?;
                 Ok((BgpEVPN::EVPN4(r.0), r.1 + 2))
             }
+            5 => {
+                let r = BgpEVPN5::decode_from(mode, &buf[2..(2 + routelen)])?;
+                Ok((BgpEVPN::EVPN5(r.0), r.1 + 2))
+            }
             _ => Err(BgpError::from_string(format!(
                 "Unsupported EVPN route type: {:?}",
                 buf
@@ -432,6 +541,10 @@ impl BgpAddrItem<BgpEVPN> for BgpEVPN {
             }
             Self::EVPN4(r) => {
                 buf[0] = 4;
+                r.encode_to(mode, &mut buf[2..])?
+            }
+            Self::EVPN5(r) => {
+                buf[0] = 5;
                 r.encode_to(mode, &mut buf[2..])?
             }
         };


### PR DESCRIPTION
This PR adds:

- EVPN type-5 (prefix advertisement) suppport
- Encode support for all supported EVPN route types

Along with a small fix to the type-2 encoding