### PR TITLE
Fix a bug with preset attribute params of BGP unknown attributes

### DIFF
--- a/src/message/attributes/unknown.rs
+++ b/src/message/attributes/unknown.rs
@@ -65,8 +65,8 @@ impl std::fmt::Display for BgpAttrUnknown {
 impl BgpAttr for BgpAttrUnknown {
     fn attr(&self) -> BgpAttrParams {
         BgpAttrParams {
-            typecode: 1,
-            flags: 64,
+            typecode: self.params.typecode,
+            flags: self.params.flags,
         }
     }
     fn encode_to(&self, _peer: &BgpSessionParams, buf: &mut [u8]) -> Result<usize, BgpError> {


### PR DESCRIPTION
BGP unknown attributes have their own defined typecode and flags. This PR fixes a bug where the defined typecode and flags weren't being used as part of the encoding process of BGP attributes.