### PR TITLE
evpn: fix type 2 serialization

### DIFF
--- a/src/afi/evpn.rs
+++ b/src/afi/evpn.rs
@@ -132,7 +132,7 @@ impl BgpAddrItem<BgpEVPN2> for BgpEVPN2 {
             )));
         };
         sz += 1;
-        let mc = MacAddress::from(&buf[sz..sz + 6]);
+        let mc = MacAddress::from_network_bytes(&buf[sz..sz + 6]);
         sz += 6;
         let addrtype = buf[sz];
         sz += 1;
@@ -181,7 +181,7 @@ impl BgpAddrItem<BgpEVPN2> for BgpEVPN2 {
         pos += 4;
         buf[pos] = 48;
         pos += 1; //mac length
-        buf[pos..pos + 6].copy_from_slice(&self.mac.mac_address);
+        self.mac.write_to_network_bytes(&mut buf[pos..pos + 6]);
         pos += 6;
         match self.ip {
             None => {

--- a/src/afi/mac.rs
+++ b/src/afi/mac.rs
@@ -28,10 +28,15 @@ impl MacAddress {
         }
     }
     /// Construct new mac address from 6 bytes in network order.
-    pub fn from(b: &[u8]) -> MacAddress {
+    pub fn from_network_bytes(b: &[u8]) -> MacAddress {
         MacAddress {
             mac_address: [b[5], b[4], b[3], b[2], b[1], b[0]],
         }
+    }
+    /// Write the mac address to the buffer in network order.
+    pub fn write_to_network_bytes(&self, b: &mut [u8]) {
+        let [b0, b1, b2, b3, b4, b5] = self.mac_address;
+        b.copy_from_slice(&[b5, b4, b3, b2, b1, b0]);
     }
     /// Construct new mac address from u64.
     pub fn from_u64(s: u64) -> MacAddress {


### PR DESCRIPTION
The MAC address is stored in reverse order from what it is on the wire; leading to a bad serialization when encoding back routes that were decoded from an actual bgp peer.

Fixes: 268ecb9 ("First release")

As a side note, why on earth are MAC addresses stored in reverse order? They are a sequence of bytes, not a compound number, thus there is no notion of "network byte order". Bytes are on the same order everywhere.

Thanks!