### PR TITLE
attr: fix cluster list and originator id serialization flags

### DIFF
--- a/src/message/attributes/clusterlist.rs
+++ b/src/message/attributes/clusterlist.rs
@@ -51,7 +51,7 @@ impl BgpAttr for BgpClusterList {
     fn attr(&self) -> BgpAttrParams {
         BgpAttrParams {
             typecode: 10,
-            flags: 80,
+            flags: 0x80,
         }
     }
     fn encode_to(&self, _peer: &BgpSessionParams, buf: &mut [u8]) -> Result<usize, BgpError> {

--- a/src/message/attributes/originatorid.rs
+++ b/src/message/attributes/originatorid.rs
@@ -56,7 +56,7 @@ impl BgpAttr for BgpOriginatorID {
     fn attr(&self) -> BgpAttrParams {
         BgpAttrParams {
             typecode: 9,
-            flags: 64,
+            flags: 0x80,
         }
     }
     fn encode_to(&self, peer: &BgpSessionParams, buf: &mut [u8]) -> Result<usize, BgpError> {


### PR DESCRIPTION
This PR fixes incorrect flags values used for the Cluster List and Originator ID path attributes, as they are not RFC compliant.